### PR TITLE
Closes #83. Trigger sync in all places

### DIFF
--- a/app/actions/labRecordImport.js
+++ b/app/actions/labRecordImport.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { join, basename } from 'path';
 import { remote } from 'electron';
 import db from '../db';
-import { syncStart } from './sync';
 
 const SET_FILE_DATA = 'SET_FILE_DATA';
 const SET_PHI_DATA = 'SET_PHI_DATA';
@@ -35,7 +34,6 @@ export const createLabRecord = () => async (dispatch, getState) => {
       });
 
       dispatch({ type: 'CREATED_LAB_RECORD', id: labRecord.id });
-      dispatch(syncStart());
       resolve(labRecord);
     });
   });

--- a/app/actions/network.js
+++ b/app/actions/network.js
@@ -3,9 +3,9 @@ import { syncStart, syncStop } from './sync';
 const NETWORK_ONLINE = 'NETWORK_ONLINE';
 const NETWORK_OFFLINE = 'NETWORK_OFFLINE';
 
-export const setNetworkOnline = () => dispatch => {
+export const setNetworkOnline = () => async dispatch => {
+  await dispatch({ type: NETWORK_ONLINE });
   dispatch(syncStart());
-  dispatch({ type: NETWORK_ONLINE });
 };
 export const setNetworkOffline = () => dispatch => {
   // TODO: Implement stop

--- a/app/actions/patient.js
+++ b/app/actions/patient.js
@@ -31,6 +31,7 @@ export const createPatient = (attributes: Attributes) => async (
   return Patient.create({ ...attributes, siteId: site.id })
     .then(record => {
       dispatch({ type: SAVED_PATIENT, record });
+      // Trigger sync because creating a patient doesn't navigate to a new location
       dispatch(syncStart());
       return dispatch(fetchPatients({ siteId: site.id }));
     })

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -67,8 +67,8 @@ export const entities = [
 ];
 
 export const syncStart = () => async (dispatch, getState) => {
-  const { sync } = getState();
-  if (sync.synchronizing) return;
+  const { sync, network } = getState();
+  if (sync.synchronizing || !network.online) return;
 
   dispatch({ type: SYNC_START });
   setTimeout(

--- a/app/components/PatientEntriesForm.js
+++ b/app/components/PatientEntriesForm.js
@@ -20,7 +20,6 @@ import {
   byValue as antibioticPrescriptionTimeByValue
 } from '../models/antibioticPrescriptionTimes';
 import isDate from '../utils/isDate';
-import { syncStart } from '../actions/sync';
 import TextArea from './TextArea';
 import EnumSelector from './EnumSelector';
 
@@ -63,7 +62,6 @@ class PatientEntriesForm extends Component<Props, State> {
         })
       );
     }
-    dispatch(syncStart());
     history.push(`/patients/${patientId}/entries`);
   };
 

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -3,18 +3,31 @@ import * as React from 'react';
 
 import { Cell, Grid, Row } from '@material/react-layout-grid';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import type { ContextRouter } from 'react-router';
+import { syncStart } from '../actions/sync';
+import { Dispatch } from '../reducers/types';
 
 import NavBar from '../components/NavBar';
 
 type Props = {
   children: React.Node,
-  user: { data: {} }
-};
+  user: { data: {} },
+  dispatch: Dispatch,
+  location: {
+    pathname: string
+  }
+} & ContextRouter;
 
 const mapStateToProps = ({ user }) => ({ user });
 
 class App extends React.Component<Props> {
-  props: Props;
+  componentDidUpdate(prevProps) {
+    const { dispatch, location } = this.props;
+    if (location.pathname !== prevProps.location.pathname) {
+      dispatch(syncStart());
+    }
+  }
 
   render() {
     const { children, user } = this.props;
@@ -31,4 +44,4 @@ class App extends React.Component<Props> {
   }
 }
 
-export default connect(mapStateToProps)(App);
+export default connect(mapStateToProps)(withRouter(App));

--- a/app/index.js
+++ b/app/index.js
@@ -25,6 +25,7 @@ store.subscribe(
 
 window.addEventListener('online', () => store.dispatch(setNetworkOnline()));
 window.addEventListener('offline', () => store.dispatch(setNetworkOffline()));
+if (!navigator.onLine) store.dispatch(setNetworkOffline());
 if (store.getState().user.data)
   setTimeout(() => store.dispatch(syncStart()), 300);
 


### PR DESCRIPTION
A sync is triggered whenever the router changes the location.
Keeps previous syncs that are fired without a change in the routes.
Also, adds early return in sync if network is offline.