### PR TITLE
Remove `rows` from LRI index

### DIFF
--- a/app/actions/antibioticConsumptionStats.js
+++ b/app/actions/antibioticConsumptionStats.js
@@ -93,15 +93,15 @@ export const fetchAntibioticConsumptionStatsList = (
     fetchAction: FETCH_ANTIBIOTIC_CONSUMPTION_STATS_LIST,
     fetchSucceededAction: FETCH_ANTIBIOTIC_CONSUMPTION_STATS_LIST_SUCCEEDED,
     fetchFailedAction: FETCH_ANTIBIOTIC_CONSUMPTION_STATS_LIST_FAILED
-  })(
-    {
+  })({
+    where: {
       ...where,
       [Sequelize.Op.or]: [{ deletedAt: null }, { deletedAt: 'Invalid date' }]
     },
     order,
     startInLastPage,
     perPage
-  );
+  });
 
 export const addCreatedAntibioticConsumptionStat = createdACS => dispatch =>
   dispatch({

--- a/app/actions/antibiotics.js
+++ b/app/actions/antibiotics.js
@@ -65,6 +65,6 @@ export const uploadAntibiotics = () => async (
 export const fetchAntibiotics = (
   where: {} = {},
   order: Array<Array<string>> = [['name', 'asc']]
-) => fetchEntity('Antibiotic')(where, order);
+) => fetchEntity('Antibiotic')({ where, order });
 
 export { FETCH_ANTIBIOTICS, FETCHED_ANTIBIOTICS, FETCH_ANTIBIOTICS_FAILED };

--- a/app/actions/electronicPharmacyStockRecords.js
+++ b/app/actions/electronicPharmacyStockRecords.js
@@ -26,9 +26,8 @@ const uploadMapper = async (attr, record) => {
   });
 };
 
-export const fetchElectronicPharmacyStockRecords = fetchEntity(
-  'ElectronicPharmacyStockRecord'
-);
+export const fetchElectronicPharmacyStockRecords = (where, attributes) =>
+  fetchEntity('ElectronicPharmacyStockRecord')({ where, attributes });
 export const fetchElectronicPharmacyStockRecord = fetchEntitySingular(
   'ElectronicPharmacyStockRecord'
 );

--- a/app/actions/fetch.js
+++ b/app/actions/fetch.js
@@ -3,12 +3,13 @@ import { constantCase } from 'change-case';
 import pluralize from 'pluralize';
 import db from '../db';
 
-const fetchEntity = (entityName, actions) => (
+const fetchEntity = (entityName, actions) => ({
   where = {},
+  attributes = { exclude: [] },
   order = [['id', 'desc']],
   startInLastPage = false,
   perPage = 20
-) => async (dispatch, getState) => {
+}) => async (dispatch, getState) => {
   const pluralizedEntityName = constantCase(pluralize(entityName));
 
   const actualActions = actions || {
@@ -30,7 +31,7 @@ const fetchEntity = (entityName, actions) => (
   const nextPage = currentPage < totalPages ? currentPage + 1 : null;
   const offset = (currentPage - 1) * perPage;
   entity
-    .findAll({ where, offset, limit: perPage, order })
+    .findAll({ attributes, where, offset, limit: perPage, order })
     .then(items =>
       dispatch({
         type: actualActions.fetchSucceededAction,

--- a/app/actions/fetch.js
+++ b/app/actions/fetch.js
@@ -9,7 +9,7 @@ const fetchEntity = (entityName, actions) => ({
   order = [['id', 'desc']],
   startInLastPage = false,
   perPage = 20
-}) => async (dispatch, getState) => {
+} = {}) => async (dispatch, getState) => {
   const pluralizedEntityName = constantCase(pluralize(entityName));
 
   const actualActions = actions || {
@@ -17,6 +17,14 @@ const fetchEntity = (entityName, actions) => ({
     fetchSucceededAction: `FETCHED_${pluralizedEntityName}`,
     fetchFailedAction: `FETCH_${pluralizedEntityName}_FAILED`
   };
+  if (entityName === 'Site') {
+    console.log('- - - FETCHING SITES - - - ');
+    console.log(where);
+    console.log(attributes);
+    console.log(order);
+    console.log(startInLastPage);
+    console.log(perPage);
+  }
 
   dispatch({ type: actualActions.fetchAction, where });
 

--- a/app/actions/fetch.js
+++ b/app/actions/fetch.js
@@ -17,14 +17,6 @@ const fetchEntity = (entityName, actions) => ({
     fetchSucceededAction: `FETCHED_${pluralizedEntityName}`,
     fetchFailedAction: `FETCH_${pluralizedEntityName}_FAILED`
   };
-  if (entityName === 'Site') {
-    console.log('- - - FETCHING SITES - - - ');
-    console.log(where);
-    console.log(attributes);
-    console.log(order);
-    console.log(startInLastPage);
-    console.log(perPage);
-  }
 
   dispatch({ type: actualActions.fetchAction, where });
 

--- a/app/actions/labRecords.js
+++ b/app/actions/labRecords.js
@@ -116,7 +116,9 @@ export const uploadUpdatedLabRecords = () => async (dispatch, getState) => {
   );
 };
 
-export const fetchLabRecords = fetchEntity('LabRecord');
+export const fetchLabRecords = (where, attributes) =>
+  fetchEntity('LabRecord')({ where, attributes });
+
 export const fetchLabRecord = labRecordId => async (dispatch, getState) => {
   dispatch({ type: FETCHING_LAB_RECORD });
   const { user } = getState();

--- a/app/actions/patientEntries.js
+++ b/app/actions/patientEntries.js
@@ -39,7 +39,8 @@ const uploadMapper = async attrs => {
   });
 };
 
-export const fetchPatientEntries = fetchEntity('PatientEntry');
+export const fetchPatientEntries = where =>
+  fetchEntity('PatientEntry')({ where });
 export const syncPatientEntries = () => async (dispatch, getState) => {
   const { user } = getState();
   dispatch({ type: SYNC_PATIENT_ENTRIES });

--- a/app/actions/patientEntry.js
+++ b/app/actions/patientEntry.js
@@ -40,7 +40,7 @@ export const createPatientEntry = attributes => async (dispatch, getState) => {
   const record = await PatientEntry.create(attributes);
 
   dispatch({ type: SAVED_PATIENT_ENTRY, record });
-  return dispatch(fetchPatientEntries());
+  return dispatch(fetchPatientEntries({ patientId: attributes.patientId }));
 };
 
 export {

--- a/app/actions/patients.js
+++ b/app/actions/patients.js
@@ -24,7 +24,7 @@ const mapper = attrs =>
 const uploadMapper = async attrs =>
   snakeCaseKeys({ ...attrs.dataValues, siteId: await attrs.getRemoteSiteId() });
 
-export const fetchPatients = fetchEntity('Patient');
+export const fetchPatients = where => fetchEntity('Patient')({ where });
 export const syncPatients = () => async (dispatch, getState) => {
   const { user, site } = getState();
   dispatch({ type: SYNC_PATIENTS });

--- a/app/actions/sites.js
+++ b/app/actions/sites.js
@@ -26,6 +26,6 @@ export const syncSites = () => async (dispatch, getState) => {
   );
 };
 
-export const fetchSites = fetchEntity('Site');
+export const fetchSites = where => fetchEntity('Site')({ where });
 
 export { FETCH_SITES, FETCHED_SITES, FETCH_SITES_FAILED };

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -81,7 +81,10 @@ export const syncStart = () => async (dispatch, getState) => {
           Promise.resolve()
         )
         .then(() => dispatch({ type: SYNC_FINISH }))
-        .catch(() => dispatch({ type: SYNC_FINISH })),
+        .catch(err => {
+          console.error(err);
+          return dispatch({ type: SYNC_FINISH });
+        }),
     300
   );
 };

--- a/app/components/ElectronicPharmacyStockRecordsList.js
+++ b/app/components/ElectronicPharmacyStockRecordsList.js
@@ -38,7 +38,12 @@ class ElectronicPharmacyStockRecordslist extends Component<Props, State> {
 
   componentDidMount() {
     const { dispatch, site } = this.props;
-    dispatch(fetchElectronicPharmacyStockRecords({ siteId: site.id }));
+    dispatch(
+      fetchElectronicPharmacyStockRecords({
+        where: { siteId: site.id },
+        attributes: ['id', 'fileName', 'createdAt']
+      })
+    );
   }
 
   render() {

--- a/app/components/ElectronicPharmacyStockRecordsList.js
+++ b/app/components/ElectronicPharmacyStockRecordsList.js
@@ -39,10 +39,11 @@ class ElectronicPharmacyStockRecordslist extends Component<Props, State> {
   componentDidMount() {
     const { dispatch, site } = this.props;
     dispatch(
-      fetchElectronicPharmacyStockRecords({
-        where: { siteId: site.id },
-        attributes: ['id', 'fileName', 'createdAt']
-      })
+      fetchElectronicPharmacyStockRecords({ siteId: site.id }, [
+        'id',
+        'fileName',
+        'createdAt'
+      ])
     );
   }
 
@@ -65,7 +66,13 @@ class ElectronicPharmacyStockRecordslist extends Component<Props, State> {
           prevPage={electronicPharmacyStockRecords.prevPage}
           nextPage={electronicPharmacyStockRecords.nextPage}
           onReload={() =>
-            dispatch(fetchElectronicPharmacyStockRecords({ siteId: site.id }))
+            dispatch(
+              fetchElectronicPharmacyStockRecords({ siteId: site.id }, [
+                'id',
+                'fileName',
+                'createdAt'
+              ])
+            )
           }
           onClick={({ id }) =>
             history.push(`/electronic_pharmacy_stock_records/${id}`)

--- a/app/components/LabRecordsList.js
+++ b/app/components/LabRecordsList.js
@@ -38,7 +38,12 @@ class LabRecordsList extends Component<Props, State> {
 
   componentDidMount() {
     const { dispatch, site } = this.props;
-    dispatch(fetchLabRecords({ siteId: site.id }));
+    dispatch(
+      fetchLabRecords({
+        where: { siteId: site.id },
+        attributes: ['id', 'fileName', 'createdAt']
+      })
+    );
   }
 
   render() {

--- a/app/components/LabRecordsList.js
+++ b/app/components/LabRecordsList.js
@@ -39,10 +39,7 @@ class LabRecordsList extends Component<Props, State> {
   componentDidMount() {
     const { dispatch, site } = this.props;
     dispatch(
-      fetchLabRecords({
-        where: { siteId: site.id },
-        attributes: ['id', 'fileName', 'createdAt']
-      })
+      fetchLabRecords({ siteId: site.id }, ['id', 'fileName', 'createdAt'])
     );
   }
 
@@ -59,7 +56,15 @@ class LabRecordsList extends Component<Props, State> {
           limit={labRecords.limit}
           prevPage={labRecords.prevPage}
           nextPage={labRecords.nextPage}
-          onReload={() => dispatch(fetchLabRecords({ siteId: site.id }))}
+          onReload={() =>
+            dispatch(
+              fetchLabRecords({ siteId: site.id }, [
+                'id',
+                'fileName',
+                'createdAt'
+              ])
+            )
+          }
           onClick={({ id }) => history.push(`/lab_records/${id}`)}
           columns={['File', 'Created at']}
           fields={['fileName', 'createdAt']}

--- a/app/components/RowForm.js
+++ b/app/components/RowForm.js
@@ -20,7 +20,7 @@ class RowForm extends Component<Props> {
         {children.map((child, index) => (
           <td
             key={`row-form-${index}`}
-            colspan={index === children.length - 1 ? 2 : 1}
+            colSpan={index === children.length - 1 ? 2 : 1}
             onKeyPress={this.handleKeyPress}
           >
             {cloneElement(child, {})}


### PR DESCRIPTION
For #314 

## Approach

A new param `attributes` is added to the `fetchEntity` method so we can ask for specific properties of the models. This is particularly useful to avoid fetching the rows of the files for `labRecordImport` and `electronicPharmacyStockRecords`.

Additionally, I turned the arguments into named ones to avoid depending on the order on which they are passed. 