### PR TITLE
Point production collectors to *.maap.aslm.org

### DIFF
--- a/environments.js
+++ b/environments.js
@@ -10,105 +10,105 @@ module.exports = [
     name: 'demo',
     config: {
       NAME: 'demo',
-      API_URL: 'https://maap-demo.instedd.org'
+      API_URL: 'https://demo.maap.aslm.org'
     }
   },
   {
     name: 'bf',
     config: {
       NAME: 'bf',
-      API_URL: 'https://maap-bf.instedd.org'
+      API_URL: 'https://bf.maap.aslm.org'
     }
   },
   {
     name: 'zw',
     config: {
       NAME: 'zw',
-      API_URL: 'https://maap-zw.instedd.org'
+      API_URL: 'https://zw.maap.aslm.org'
     }
   },
   {
     name: 'sz',
     config: {
       NAME: 'sz',
-      API_URL: 'https://maap-sz.instedd.org'
+      API_URL: 'https://sz.maap.aslm.org'
     }
   },
   {
     name: 'ug',
     config: {
       NAME: 'ug',
-      API_URL: 'https://maap-ug.instedd.org'
+      API_URL: 'https://ug.maap.aslm.org'
     }
   },
   {
     name: 'tz',
     config: {
       NAME: 'tz',
-      API_URL: 'https://maap-tz.instedd.org'
+      API_URL: 'https://tz.maap.aslm.org'
     }
   },
   {
     name: 'ke',
     config: {
       NAME: 'ke',
-      API_URL: 'https://maap-ke.instedd.org'
+      API_URL: 'https://ke.maap.aslm.org'
     }
   },
   {
     name: 'ng',
     config: {
       NAME: 'ng',
-      API_URL: 'https://maap-ng.instedd.org'
+      API_URL: 'https://ng.maap.aslm.org'
     }
   },
   {
     name: 'mw',
     config: {
       NAME: 'mw',
-      API_URL: 'https://maap-mw.instedd.org'
+      API_URL: 'https://mw.maap.aslm.org'
     }
   },
   {
     name: 'sl',
     config: {
       NAME: 'sl',
-      API_URL: 'https://maap-sl.instedd.org'
+      API_URL: 'https://sl.maap.aslm.org'
     }
   },
   {
     name: 'gh',
     config: {
       NAME: 'gh',
-      API_URL: 'https://maap-gh.instedd.org'
+      API_URL: 'https://gh.maap.aslm.org'
     }
   },
   {
     name: 'ga',
     config: {
       NAME: 'ga',
-      API_URL: 'https://maap-ga.instedd.org'
+      API_URL: 'https://ga.maap.aslm.org'
     }
   },
   {
     name: 'cm',
     config: {
       NAME: 'cm',
-      API_URL: 'https://maap-cm.instedd.org'
+      API_URL: 'https://cm.maap.aslm.org'
     }
   },
   {
     name: 'zm',
     config: {
       NAME: 'zm',
-      API_URL: 'https://maap-zm.instedd.org'
+      API_URL: 'https://zm.maap.aslm.org'
     }
   },
   {
     name: 'sn',
     config: {
       NAME: 'sn',
-      API_URL: 'https://maap-sn.instedd.org'
+      API_URL: 'https://sn.maap.aslm.org'
     }
   }
 ];


### PR DESCRIPTION
We've migrated the maap-stores under the maap.aslm.org domain, so this commit updates the collectors to use the new URLs.

Old collectors still work due to redirections set on the old `maap-xx.instedd.org` domains to the new locations, but this
change will avoid redundant requests (collectors now make a request to the `instedd.org` subdomain, get a redirection as
response, then repeate the request to the `maap.aslm.org` subdomain).

We haven't migrated staging (at least yet), so we are not upgrading that.